### PR TITLE
feat(schema+cli): enforce localized slugs for categories/docs; add nav validate command; strict sibling-category uniqueness; wire --strict to gen; update README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ Options:
   --validate                 Validate against existing navigation schema (default: true)
   --report                   Generate detailed report (default: false)
   --fix                      Auto-fix common issues (default: false)
+  --strict                   Fail generation when validation errors are found (default: false)
   -l, --languages <langs>    Comma-separated languages to process (en,es,pt) (default: "en,es,pt")
   -s, --sections <sections>  Comma-separated sections to process (leave empty for all)
   -v, --verbose              Show detailed log lines in terminal (default: false)
@@ -70,6 +71,29 @@ Options:
   --log-file <file>          Export detailed logs to file
   --show-warnings            Display detailed analysis of all warnings (default: false)
 ```
+
+### ✅ Validation
+
+Validate a navigation.json file (schema + custom cross-node checks):
+
+```bash
+# Validate and print issues (non-zero exit only if --strict)
+vtex-nav validate ./public/navigation.json
+
+# Fail the build if any errors are found
+vtex-nav validate ./public/navigation.json --strict
+```
+
+What’s validated:
+- Structural JSON Schema (Draft-07)
+  - name and slug are LocalizedString objects with en, es, pt keys
+  - Categories: type=category, children min 1
+  - Documents: type=markdown, children must be empty
+  - Additional properties are rejected for safety
+- Custom rule: sibling categories under the same parent must have unique english slug (slug.en)
+
+Notes:
+- Empty strings are allowed in LocalizedString fields to indicate a missing translation. This keeps the structure consistent while signalling gaps.
 
 ### 🌳 Viewing Navigation
 
@@ -241,6 +265,25 @@ vtex-nav view --file latest-nav.json
 # Generate detailed report for review
 vtex-nav gen --report --log-file generation.log
 ```
+
+## Schema overview
+
+LocalizedString
+- Keys: en, es, pt
+- Value: string (can be empty to indicate missing translation)
+
+NavigationNode
+- name: LocalizedString
+- slug: LocalizedString
+- type: "category" | "markdown"
+- children: NavigationNode[]
+- Rules:
+  - category: children.length >= 1
+  - markdown: children.length == 0
+
+Merging and duplicates
+- Categories across languages are merged by their English slug (slug.en), treating categories as localized entities.
+- Within the same parent, sibling category english slugs must be unique; duplicates are flagged by validation.
 
 ## Architecture
 

--- a/scripts/validate-nav.js
+++ b/scripts/validate-nav.js
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+/*
+  Validator for VTEX Help Center navigation.json
+
+  Checks performed:
+  - Duplicate categories by English slug (global and per-parent)
+  - Localization coverage per category (expected: en, es, pt)
+  - Empty categories (no children)
+  - Mixed-language children under a single category (FYI)
+  - Summary counts (nodes, categories, documents, per-locale docs)
+
+  Usage:
+  node scripts/validate-nav.js [path_to_navigation.json] [--expected-locales=en,es,pt] [--max-report=50]
+*/
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function parseArgs(argv) {
+  const args = { file: null, expectedLocales: ['en', 'es', 'pt'], maxReport: 100 };
+  for (const arg of argv.slice(2)) {
+    if (!arg.startsWith('--')) {
+      args.file = arg;
+      continue;
+    }
+    const [k, v] = arg.split('=');
+    if (k === '--expected-locales') {
+      args.expectedLocales = v.split(',').map(s => s.trim()).filter(Boolean);
+    } else if (k === '--max-report') {
+      args.maxReport = Number(v) || args.maxReport;
+    }
+  }
+  if (!args.file) {
+    // Default to sibling repo help-center-content next to vtexhelp-nav-cli root
+    args.file = path.resolve(__dirname, '../../help-center-content/public/navigation.json');
+  } else {
+    args.file = path.resolve(process.cwd(), args.file);
+  }
+  return args;
+}
+
+function isPlainObject(v) {
+  return v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function slugify(str) {
+  return String(str || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}
+
+function getEnglishSlug(node) {
+  if (!node || typeof node !== 'object') return undefined;
+  // Most likely properties
+  const candidates = [
+    node.slugEN,
+    node.slugEn,
+    node.englishSlug,
+    node.enSlug,
+    node.legacySlugEN,
+  ];
+  for (const c of candidates) if (typeof c === 'string' && c) return c;
+
+  // Mapped slugs per locale
+  const mapCandidates = [node.slugByLocale, node.slug_i18n, node.slug, node.slugs];
+  for (const m of mapCandidates) {
+    if (isPlainObject(m) && typeof m.en === 'string' && m.en) return m.en;
+  }
+
+  // As a very last resort, try deriving from localized name
+  const name = node.name || node.title || node.label;
+  if (isPlainObject(name) && typeof name.en === 'string') return slugify(name.en);
+  if (typeof name === 'string') return slugify(name);
+
+  return undefined;
+}
+
+function getNodeId(node) {
+  // Try common identifiers to dedupe cycles or references
+  return node.id || node._id || node.key || node.uid || undefined;
+}
+
+function getChildren(node) {
+  if (!node || typeof node !== 'object') return [];
+  if (Array.isArray(node.children)) return node.children;
+  if (Array.isArray(node.sections)) return node.sections;
+  if (Array.isArray(node.items)) return node.items;
+  if (Array.isArray(node.nodes)) return node.nodes;
+  if (Array.isArray(node.pages)) return node.pages;
+  return [];
+}
+
+function getNodeType(node) {
+  if (!node || typeof node !== 'object') return 'unknown';
+  if (getChildren(node).length > 0) return 'category';
+  if (node.type && typeof node.type === 'string') {
+    const t = node.type.toLowerCase();
+    if (t.includes('category')) return 'category';
+    if (t.includes('doc') || t.includes('article') || t.includes('page')) return 'document';
+  }
+  // Heuristic: has a path/slug but no children
+  if ((typeof node.slug === 'string' || typeof node.path === 'string' || typeof node.url === 'string') && getChildren(node).length === 0) return 'document';
+  return 'unknown';
+}
+
+function collectLocalesFromValue(v, expectedLocales) {
+  const set = new Set();
+  if (typeof v === 'string') return set; // not localized map
+  if (isPlainObject(v)) {
+    for (const k of Object.keys(v)) {
+      if (expectedLocales.includes(k)) set.add(k);
+    }
+  }
+  return set;
+}
+
+function getNodeLocales(node, expectedLocales) {
+  const locales = new Set();
+  if (!node || typeof node !== 'object') return locales;
+
+  if (typeof node.locale === 'string') locales.add(node.locale);
+  if (Array.isArray(node.locales)) node.locales.forEach(l => typeof l === 'string' && locales.add(l));
+
+  // Look into localized fields
+  const fields = ['name', 'title', 'label', 'slug', 'slugByLocale', 'slug_i18n'];
+  for (const f of fields) {
+    const v = node[f];
+    for (const l of collectLocalesFromValue(v, expectedLocales)) locales.add(l);
+  }
+
+  // Translations arrays
+  const t = node.translations || node.i18n || node.localizedVariants;
+  if (Array.isArray(t)) {
+    for (const item of t) {
+      if (isPlainObject(item) && typeof item.locale === 'string') locales.add(item.locale);
+    }
+  }
+
+  return locales;
+}
+
+function traverse(root, expectedLocales) {
+  const state = {
+    totalNodes: 0,
+    categories: 0,
+    documents: 0,
+    unknowns: 0,
+    perLocaleDocs: new Map(), // locale -> count
+    categoriesByEnglishSlug: new Map(), // slug -> { count, nodes: [], locales:Set }
+    perParentCategoryDuplicates: [], // { parentPath, slugEN, count, nodeNames }
+    emptyCategories: [], // { path, slugEN }
+    mixedLanguageChildren: [], // { path, childLocales:[...], childCount }
+  };
+
+  const seen = new Set(); // guard against cycles
+
+  function walk(node, pathParts) {
+    if (!node || typeof node !== 'object') return;
+    const ref = node; // object reference key
+    if (seen.has(ref)) return;
+    seen.add(ref);
+
+    state.totalNodes++;
+    const type = getNodeType(node);
+    const name = node.name || node.title || node.label || '';
+    const displayName = isPlainObject(name) ? (name.en || name.es || name.pt || Object.values(name)[0] || '') : name;
+    const pathStr = pathParts.join(' / ');
+
+    if (type === 'category') {
+      state.categories++;
+      const slugEN = getEnglishSlug(node) || '(unknown)';
+      const locales = getNodeLocales(node, expectedLocales);
+
+      // Global aggregation by english slug
+      let agg = state.categoriesByEnglishSlug.get(slugEN);
+      if (!agg) {
+        agg = { count: 0, nodes: [], locales: new Set() };
+        state.categoriesByEnglishSlug.set(slugEN, agg);
+      }
+      agg.count += 1;
+      agg.nodes.push({ path: pathStr, name: displayName });
+      for (const l of locales) agg.locales.add(l);
+
+      // Children analysis
+      const children = getChildren(node);
+      if (children.length === 0) {
+        state.emptyCategories.push({ path: pathStr, slugEN });
+      }
+
+      // Per-parent duplicate detection
+      const siblingMap = new Map();
+      for (const child of children) {
+        if (getNodeType(child) !== 'category') continue;
+        const cSlug = getEnglishSlug(child) || '(unknown)';
+        const entry = siblingMap.get(cSlug) || [];
+        entry.push(child);
+        siblingMap.set(cSlug, entry);
+      }
+      for (const [slug, arr] of siblingMap) {
+        if (arr.length > 1) {
+          state.perParentCategoryDuplicates.push({
+            parentPath: pathStr,
+            slugEN: slug,
+            count: arr.length,
+            nodeNames: arr.map(c => {
+              const n = c.name || c.title || c.label;
+              return isPlainObject(n) ? (n.en || n.es || n.pt || Object.values(n)[0] || '') : (n || '');
+            }),
+          });
+        }
+      }
+
+      // Mixed-language children locales
+      const childLocales = new Set();
+      for (const child of children) {
+        const locs = getNodeLocales(child, expectedLocales);
+        for (const l of locs) childLocales.add(l);
+      }
+      if (childLocales.size > 1) {
+        state.mixedLanguageChildren.push({ path: pathStr, childLocales: Array.from(childLocales), childCount: children.length });
+      }
+
+      // Walk children
+      let idx = 0;
+      for (const child of children) {
+        const childName = child && typeof child === 'object' ? (child.name || child.title || child.label || child.id || `child-${idx}`) : `child-${idx}`;
+        const childDisplay = isPlainObject(childName) ? (childName.en || childName.es || childName.pt || Object.values(childName)[0] || '') : childName;
+        walk(child, [...pathParts, String(childDisplay)]);
+        idx++;
+      }
+    } else if (type === 'document') {
+      state.documents++;
+
+      const locales = getNodeLocales(node, expectedLocales);
+      if (locales.size === 0) {
+        // Try to infer a single-locale doc; skip counting if unknown
+      } else {
+        for (const l of locales) {
+          state.perLocaleDocs.set(l, (state.perLocaleDocs.get(l) || 0) + 1);
+        }
+      }
+    } else {
+      state.unknowns++;
+    }
+  }
+
+  walk(root, ['root']);
+  return state;
+}
+
+function printReport(state, expectedLocales, maxReport) {
+  const lines = [];
+  lines.push('Navigation validation report');
+  lines.push('');
+  lines.push(`Totals: nodes=${state.totalNodes}, categories=${state.categories}, documents=${state.documents}, unknown=${state.unknowns}`);
+  const perLoc = Array.from(state.perLocaleDocs.entries()).sort((a,b) => a[0].localeCompare(b[0]));
+  if (perLoc.length > 0) {
+    lines.push('Documents per locale:');
+    for (const [loc, count] of perLoc) lines.push(`  - ${loc}: ${count}`);
+  } else {
+    lines.push('Documents per locale: unavailable (no locale metadata found on documents)');
+  }
+
+  // Global duplicates by English slug
+  const dupes = Array.from(state.categoriesByEnglishSlug.entries()).filter(([, agg]) => agg.count > 1);
+  lines.push('');
+  lines.push(`Duplicate categories by English slug (global): ${dupes.length}`);
+  let shown = 0;
+  for (const [slug, agg] of dupes) {
+    if (shown >= maxReport) { lines.push(`  ...and ${dupes.length - shown} more`); break; }
+    lines.push(`  - slugEN="${slug}" appears ${agg.count} times at:`);
+    for (const node of agg.nodes.slice(0, 5)) {
+      lines.push(`      • ${node.path} (${node.name})`);
+    }
+    if (agg.nodes.length > 5) lines.push(`      ... +${agg.nodes.length - 5} more`);
+    const locs = Array.from(agg.locales).sort();
+    const missing = expectedLocales.filter(l => !agg.locales.has(l));
+    lines.push(`      locales: [${locs.join(', ')}], missing: [${missing.join(', ')}]`);
+    shown++;
+  }
+
+  // Per-parent duplicates
+  lines.push('');
+  lines.push(`Duplicate subcategories by English slug within the same parent: ${state.perParentCategoryDuplicates.length}`);
+  for (const item of state.perParentCategoryDuplicates.slice(0, maxReport)) {
+    lines.push(`  - parent="${item.parentPath}": slugEN="${item.slugEN}" count=${item.count} names=[${item.nodeNames.join(' | ')}]`);
+  }
+  if (state.perParentCategoryDuplicates.length > maxReport) lines.push(`  ...and ${state.perParentCategoryDuplicates.length - maxReport} more`);
+
+  // Empty categories
+  lines.push('');
+  lines.push(`Empty categories: ${state.emptyCategories.length}`);
+  for (const item of state.emptyCategories.slice(0, Math.min(maxReport, 50))) {
+    lines.push(`  - ${item.path} (slugEN=${item.slugEN})`);
+  }
+  if (state.emptyCategories.length > 50) lines.push(`  ...and ${state.emptyCategories.length - 50} more`);
+
+  // Mixed-language children
+  lines.push('');
+  lines.push(`Categories with mixed-language children (FYI): ${state.mixedLanguageChildren.length}`);
+  for (const item of state.mixedLanguageChildren.slice(0, Math.min(maxReport, 50))) {
+    lines.push(`  - ${item.path} -> locales=[${item.childLocales.join(', ')}], children=${item.childCount}`);
+  }
+  if (state.mixedLanguageChildren.length > 50) lines.push(`  ...and ${state.mixedLanguageChildren.length - 50} more`);
+
+  console.log(lines.join('\n'));
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!fs.existsSync(args.file)) {
+    console.error(`File not found: ${args.file}`);
+    process.exit(2);
+  }
+
+  const raw = fs.readFileSync(args.file, 'utf8');
+  let json;
+  try {
+    json = JSON.parse(raw);
+  } catch (e) {
+    console.error('Failed to parse JSON:', e.message);
+    process.exit(2);
+  }
+
+  // The generated file may have a root object with a known property or might already be an array/tree.
+  let root = json;
+  if (Array.isArray(json)) {
+    // Wrap as a root category
+    root = { name: 'root', children: json };
+  } else if (isPlainObject(json)) {
+    // Try common root keys
+    const keys = ['navigation', 'nav', 'root', 'sections', 'data'];
+    for (const k of keys) {
+      if (Array.isArray(json[k])) { root = { name: 'root', children: json[k] }; break; }
+      if (isPlainObject(json[k])) { root = json[k]; break; }
+    }
+    // If root-like object has a sections array, unwrap to children
+    if (isPlainObject(root) && Array.isArray(root.sections) && !Array.isArray(root.children)) {
+      root = { ...root, children: root.sections };
+    }
+  }
+
+  const state = traverse(root, args.expectedLocales);
+  printReport(state, args.expectedLocales, args.maxReport);
+}
+
+// Execute when run directly
+const entry = pathToFileURL(process.argv[1]).href;
+if (import.meta.url === entry) {
+  main();
+}
+

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {render} from 'ink';
 import App from './app.js';
 import { createSimpleGenerateCommand } from './commands/generateCommand.js';
+import { createValidateCommand } from './commands/validateCommand.js';
 
 const program = new Command()
   .name('vtexhelp-nav')
@@ -31,5 +32,8 @@ program
 
 // Add generate command (simple mode only)
 program.addCommand(createSimpleGenerateCommand());
+
+// Add validate command
+program.addCommand(createValidateCommand());
 
 program.parse();

--- a/source/commands/generateCommand.ts
+++ b/source/commands/generateCommand.ts
@@ -4,20 +4,7 @@ import generateSimple from './generate-simple.js';
 
 const DEFAULT_CONTENT_DIR = '.vtexhelp-content';
 
-interface GenerateCommandOptions {
-  contentDir?: string;
-  output?: string;
-  validate?: boolean;
-  report?: boolean;
-  fix?: boolean;
-  languages?: string;
-  sections?: string;
-  logFile?: string;
-  verbose?: boolean;
-  branch?: string;
-  force?: boolean;
-  showWarnings?: boolean;
-}
+// Using inline 'any' types in the action handler to avoid over-constraining CLI options.
 
 export function createSimpleGenerateCommand() {
   const generateSimpleCmd = new Command('gen')
@@ -27,6 +14,7 @@ export function createSimpleGenerateCommand() {
     .option('--validate', 'Validate against existing navigation schema', true)
     .option('--report', 'Generate detailed report', false)
     .option('--fix', 'Auto-fix common issues', false)
+    .option('--strict', 'Fail generation when validation errors are found', false)
     .option('-l, --languages <langs>', 'Comma-separated languages to process (en,es,pt)', 'en,es,pt')
     .option('-s, --sections <sections>', 'Comma-separated sections to process (leave empty for all)')
     .option('-v, --verbose', 'Show detailed log lines in terminal', false)
@@ -34,18 +22,18 @@ export function createSimpleGenerateCommand() {
     .option('-f, --force', 'Force overwrite existing content directory', false)
     .option('--log-file <file>', 'Export detailed logs to file')
     .option('--show-warnings', 'Display detailed analysis of all warnings', false)
-    .action(async (options: Omit<GenerateCommandOptions, 'noInteractive'>) => {
+    .action(async (options: any) => {
       try {
         // Parse language list
         const languages = options.languages
           ?.split(',')
-          .map(lang => lang.trim() as Language)
-          .filter(lang => ['en', 'es', 'pt'].includes(lang)) || ['en', 'es', 'pt'];
+          .map((lang: string) => lang.trim() as Language)
+          .filter((lang: string) => ['en', 'es', 'pt'].includes(lang)) || ['en', 'es', 'pt'];
 
         // Parse sections list  
         const sections = options.sections
           ?.split(',')
-          .map(section => section.trim())
+          .map((section: string) => section.trim())
           .filter(Boolean) || [];
 
         // Run the simple generation
@@ -62,6 +50,8 @@ export function createSimpleGenerateCommand() {
           force: options.force,
           logFile: options.logFile,
           showWarnings: options.showWarnings,
+          // pass through strict flag (not typed in GenerationOptions)
+          ...(options.strict ? { strict: true } : {})
         });
 
       } catch (error) {

--- a/source/commands/validateCommand.ts
+++ b/source/commands/validateCommand.ts
@@ -1,0 +1,73 @@
+import { Command } from 'commander';
+import pkg from 'ajv';
+const { default: Ajv } = pkg;
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export function createValidateCommand() {
+  const cmd = new Command('validate')
+    .description('Validate a navigation.json file against the schema with extra checks')
+    .argument('<file>', 'Path to navigation.json')
+    .option('--strict', 'Exit with failure code on validation errors', false)
+    .action(async (file: string, options: { strict?: boolean }) => {
+      try {
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = path.dirname(__filename);
+        let schemaPath = path.join(__dirname, '../schemas/navigation.schema.json');
+        try {
+          await fs.access(schemaPath);
+        } catch {
+          // Fallback to source schema when running from repo
+          const repoRoot = path.resolve(__dirname, '..', '..');
+          schemaPath = path.join(repoRoot, 'source', 'schemas', 'navigation.schema.json');
+        }
+        const schema = JSON.parse(await fs.readFile(schemaPath, 'utf8'));
+        const data = JSON.parse(await fs.readFile(path.resolve(file), 'utf8'));
+
+        const ajv = new Ajv({ allErrors: true, strict: true });
+        const validate = ajv.compile(schema);
+        const ok = validate(data);
+
+        const errors: string[] = [];
+        if (!ok && validate.errors) {
+          for (const e of validate.errors) {
+            errors.push(`Schema: ${e.instancePath} ${e.message}`);
+          }
+        }
+
+        // Custom: ensure sibling categories have unique English slug per parent
+        const customErrors: string[] = [];
+        const check = (nodes: any[], pathParts: string[]) => {
+          const map = new Map<string, number>();
+          for (const n of nodes || []) {
+            if (n?.type === 'category') {
+              const key = typeof n.slug === 'string' ? n.slug : n.slug?.en || '';
+              if (key) map.set(key, (map.get(key) || 0) + 1);
+            }
+          }
+          for (const [k, count] of map) {
+            if (count > 1) customErrors.push(`Duplicate category englishSlug '${k}' at ${pathParts.join(' > ')}`);
+          }
+          for (const n of nodes || []) if (n?.type === 'category') check(n.children || [], [...pathParts, n.name?.en || '(category)']);
+        };
+        for (const sec of data.navbar || []) check(sec.categories || [], [sec.documentation || 'section']);
+
+        const allErrors = [...errors, ...customErrors];
+        if (allErrors.length === 0) {
+          console.log('✅ navigation.json is valid');
+        } else {
+          console.error('❌ Validation failed:');
+          for (const err of allErrors) console.error(' -', err);
+        }
+
+        if (options.strict && allErrors.length > 0) process.exit(1);
+      } catch (err) {
+        console.error('❌ Validation error:', err);
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}
+

--- a/source/schemas/navigation.schema.json
+++ b/source/schemas/navigation.schema.json
@@ -5,10 +5,12 @@
   "description": "Schema for VTEX documentation portal navigation structure",
   "type": "object",
   "required": ["navbar"],
+  "additionalProperties": false,
   "properties": {
     "navbar": {
       "type": "array",
       "description": "Top-level navigation sections",
+      "minItems": 1,
       "items": {
         "$ref": "#/definitions/navbarItem"
       }
@@ -19,6 +21,7 @@
       "type": "object",
       "description": "A top-level navigation section",
       "required": ["documentation", "name", "slugPrefix", "categories"],
+      "additionalProperties": false,
       "properties": {
         "documentation": {
           "type": "string",
@@ -37,6 +40,7 @@
         "categories": {
           "type": "array",
           "description": "Categories within this section",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/navigationNode"
           }
@@ -47,6 +51,7 @@
       "type": "object",
       "description": "A navigation node that can be either a category or a document",
       "required": ["name", "slug", "type", "children"],
+      "additionalProperties": false,
       "properties": {
         "name": {
           "$ref": "#/definitions/localizedString",
@@ -54,16 +59,10 @@
         },
         "slug": {
           "oneOf": [
-            {
-              "type": "string",
-              "description": "Simple slug string"
-            },
-            {
-              "$ref": "#/definitions/localizedString",
-              "description": "Localized slug object"
-            }
+            { "$ref": "#/definitions/localizedString" },
+            { "type": "string" }
           ],
-          "description": "URL slug for this node (can be string or localized object)"
+          "description": "URL slug for this node (localized object is preferred)"
         },
         "origin": {
           "type": "string",
@@ -82,25 +81,36 @@
             "$ref": "#/definitions/navigationNode"
           }
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "type": { "const": "category" } } },
+          "then": {
+            "properties": {
+              "slug": { "$ref": "#/definitions/localizedString" },
+              "children": { "type": "array", "minItems": 1 }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "type": { "const": "markdown" } } },
+          "then": {
+            "properties": {
+              "slug": { "$ref": "#/definitions/localizedString" },
+              "children": { "type": "array", "maxItems": 0 }
+            }
+          }
+        }
+      ]
     },
     "localizedString": {
       "type": "object",
       "description": "Object containing localized strings for different languages",
       "required": ["en", "es", "pt"],
       "properties": {
-        "en": {
-          "type": "string",
-          "description": "English translation"
-        },
-        "es": {
-          "type": "string",
-          "description": "Spanish translation"
-        },
-        "pt": {
-          "type": "string",
-          "description": "Portuguese translation"
-        }
+        "en": { "type": "string" },
+        "es": { "type": "string" },
+        "pt": { "type": "string" }
       },
       "additionalProperties": false
     }

--- a/source/types/navigation.ts
+++ b/source/types/navigation.ts
@@ -24,7 +24,7 @@ export interface NavigationNode {
   /** Localized name of the node */
   name: LocalizedString;
   
-  /** URL slug - can be either a simple string or localized object */
+  /** URL slug - localized object (strings can be used during build but output is localized) */
   slug: string | LocalizedString;
   
   /** Origin field (typically empty string) */


### PR DESCRIPTION
#### What is the purpose of this pull request?

Introduce a stricter, schema-driven contract for navigation.json and a first-class validation command, ensuring consistency with the Help Center UI and preventing duplicate categories across locales.

#### What problem is this solving?

- Categories and documents had mixed slug shapes (sometimes string, sometimes localized), which complicated consumers and could cause mismatches.
- Sibling categories with identical English slugs (the merge key) could appear twice under the same parent, producing duplicated items in the sidebar.
- There was no single, CLI-first way to validate navigation.json in CI beyond generation.

#### What does this change?

Schema (source/schemas/navigation.schema.json)
- Enforce LocalizedString for slug and name (keys: en, es, pt). Empty strings are allowed to signal a missing translation without breaking structure.
- Categories: type=category with children min 1.
- Documents: type=markdown with children max 0.
- additionalProperties: false across structures; navbar minItems: 1.

Generator
- Categories now always emit slug as LocalizedString (en filled, es/pt may be empty). Documents already did.
- Category merge key uses slug.en, so categories are treated as localized entities and are merged correctly across locales.
- Added --strict to gen; in strict mode, generation fails if validation errors are found.

Validation command
- New `vtex-nav validate <file> [--strict]` command.
- Runs JSON Schema validation and a custom cross-node rule: sibling categories under the same parent must have unique english slug (slug.en).

README
- Documented the validate command, strict mode, and the schema overview.

#### How should this be manually tested?

1) Build CLI and generate navigation with strict validation:
```bash
npm run build
node dist/cli.js gen \
  --content-dir ../help-center-content \
  --output ../help-center-content/public/navigation.json \
  --validate --strict --force
```

2) Validate the output explicitly:
```bash
node dist/cli.js validate ../help-center-content/public/navigation.json --strict
```
Expected: "✅ navigation.json is valid". Any duplicate sibling categories or schema violations will fail the command in strict mode.

#### Screenshots or example usage

- Validation success (strict): `✅ navigation.json is valid`
- Example error (strict): `Duplicate category englishSlug 'data-and-privacy' at tracks`

#### Types of changes

- [x] New feature (adds validation command)
- [x] Improvement (stricter schema + generator alignment)
- [ ] Breaking change (No; localized slug output is backward-compatible in shape with prior LocalizedString usage)
- [x] Documentation update (README)

#### Rollout/CI notes

- Consider adding `vtex-nav validate ./public/navigation.json --strict` to the GitHub Actions workflow after generation so PRs fail on schema violations or duplicate categories.
