### PR TITLE
docs: refresh README and add troubleshooting guide

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,85 @@
+# Troubleshooting
+
+This page lists practical steps to diagnose and fix common issues when generating or validating the Help Center navigation.
+
+If you get stuck, collect the diagnostics below and open an issue with the details.
+
+## Quick fixes
+
+- Reset local caches and regenerate
+  ```bash
+  rm -rf .vtexhelp-content .vtexhelp-known-issues generated-navigation.json
+  vtex-nav gen --verbose --show-warnings --log-file generation.log
+  ```
+- Narrow the scope to isolate a problem
+  ```bash
+  vtex-nav gen --languages en --sections announcements --verbose --log-file generation.log
+  ```
+
+## Common issues
+
+### Parse errors from known-issues repository
+- Cause: malformed YAML frontmatter in external entries.
+- Impact: files are skipped; generation completes. Counts are reported.
+- Workarounds:
+  - Ignore unless you are using `--strict`.
+  - Exclude the section while debugging:
+    ```bash
+    vtex-nav gen --sections announcements,faq,tracks,tutorials,troubleshooting
+    ```
+
+### Duplicate slug conflicts
+- Announcements month categories repeat across years (e.g., "september"). Today the validator flags duplicates across the whole section.
+- We plan to scope duplicate checks to siblings only (unique among the same parent).
+- Until then:
+  - Avoid `--strict` if month duplicates are the only errors.
+  - Or filter/patch validation in CI to treat same-name months across years as OK.
+
+### Category order seems ignored
+- Ensure there is a `metadata.json` inside the category folder (per language) with a numeric `order` field. Example:
+  ```json
+  { "id": "catalog", "name": "Catalog", "slug": "catalog", "order": 10 }
+  ```
+- The generator reads `metadata.json` for all sections and sorts categories by `order`. Fallback is alphabetical.
+
+### Announcements not ordered newest-first
+- Month article ordering relies on the filename/slug prefix `YYYY-MM-DD-...`.
+- Ensure articles under `announcements/<year>/<month>/` start with a date prefix.
+
+### "No navigation.json to view"
+- Generate first or define the source URL in `.env`:
+  ```env
+  VTEX_NAVIGATION_URL=https://newhelp.vtex.com/navigation.json
+  ```
+- Then run:
+  ```bash
+  vtex-nav view --file ./generated-navigation.json
+  ```
+
+## Diagnostics
+
+- Rerun with logs and verbose output
+  ```bash
+  vtex-nav gen --verbose --show-warnings --log-file generation.log
+  vtex-nav validate ./generated-navigation.json --strict
+  ```
+- Collect environment info (include in bug reports)
+  ```bash
+  node -v
+  npm -v
+  git rev-parse HEAD
+  ```
+- Minimal reproduction
+  ```bash
+  rm -rf .vtexhelp-content .vtexhelp-known-issues
+  vtex-nav gen --languages en --sections announcements --verbose --log-file generation.log
+  ```
+
+## Reporting a bug
+
+Include the following:
+- Exact command(s) and full output (or `generation.log`)
+- `generated-navigation.json` (or a reduced snippet if sensitive)
+- Node and npm versions; OS; current commit (`git rev-parse HEAD`)
+- Whether you used `--strict`, `--show-warnings`, or section/language filters
+- The smallest command that reproduces the issue

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,8 @@ Generation pipeline:
 
 ### Validation
 
+See also: Troubleshooting guide at docs/troubleshooting.md
+
 - JSON Schema (Draft‑07) at `source/schemas/navigation.schema.json`
   - name and slug are LocalizedString objects with en, es, pt keys
   - Categories: type=category, children >= 1

--- a/readme.md
+++ b/readme.md
@@ -1,315 +1,141 @@
 # VTEX Navigation CLI
 
-A comprehensive command-line tool for both **generating** and **viewing** VTEX documentation navigation structures.
+A command-line tool that generates and previews the VTEX Help Center navigation (navigation.json). It is designed for CI/CD and local inspection.
 
-## Features
+- Generates a unified, multilingual navigation from the Help Center content repositories
+- Validates output against a JSON Schema plus custom rules
+- Includes a simple viewer for quick inspection
 
-### 🏗️ Navigation Generation
-- 🤖 **Intelligent Generation**: Automatically generates navigation from VTEX Help Center content repository
-- 🎯 **Simple Generation**: Console-only generator focused on speed and clarity
-- 🌍 **Multi-language Support**: Processes English, Spanish, and Portuguese content with proper localized slugs
-- 🔗 **Cross-language Linking**: Automatically links related documents across languages
-- 📝 **Smart Slug Generation**: Prioritizes `legacySlug` → filename-based → empty string for missing translations
-- 🔍 **Intelligent Duplicate Detection**: Only warns about true duplicates (same section + language), not multilingual documents
-- 📊 **Validation & Reports**: Built-in validation with detailed reporting capabilities
-- ⚡ **Performance Optimized**: Simple mode offers ~13% better performance
-
-### 🌳 Interactive Viewer
-- 🌳 **Interactive Tree View**: Navigate through the VTEX documentation structure with keyboard controls
-- 🌍 **Multi-language Support**: Switch between English, Spanish, and Portuguese on the fly
-- 📊 **Statistics**: View detailed statistics about the documentation structure
-- 💾 **Auto-download**: Automatically downloads the navigation file if not present locally
-- ⚡ **Fast Navigation**: Keyboard shortcuts for efficient browsing
-
-## Installation
+## Install
 
 ```bash
 npm install -g vtexhelp-nav-cli
-```
-
-Or run directly with npx:
-
-```bash
+# or
 npx vtexhelp-nav-cli
 ```
 
-## Usage
-
-Note: The executable name is vtex-nav (alias: vtexhelp-nav-cli).
-
-### 🏗️ Navigation Generation
-
-The CLI currently provides a simple, console-only generation command:
-
-#### Simple Mode (Recommended for CI/CD)
-```bash
-# Generate navigation with clean console output
-vtexhelp-nav gen
-
-# Generate with custom options
-vtexhelp-nav gen --output custom-nav.json --verbose --force
-
-# Generate specific languages only
-vtexhelp-nav gen --languages en,es --report
-```
-
-
-#### Generation Options
-```
-Options:
-  -d, --content-dir <dir>    Directory to clone/use content from (default: ".vtexhelp-content")
-  -o, --output <file>        Output navigation.json file path (default: "generated-navigation.json")
-  --validate                 Validate against existing navigation schema (default: true)
-  --report                   Generate detailed report (default: false)
-  --fix                      Auto-fix common issues (default: false)
-  --strict                   Fail generation when validation errors are found (default: false)
-  -l, --languages <langs>    Comma-separated languages to process (en,es,pt) (default: "en,es,pt")
-  -s, --sections <sections>  Comma-separated sections to process (leave empty for all)
-  -v, --verbose              Show detailed log lines in terminal (default: false)
-  -b, --branch <branch>      Git branch to clone (default: "main")
-  -f, --force                Force overwrite existing content directory (default: false)
-  --log-file <file>          Export detailed logs to file
-  --show-warnings            Display detailed analysis of all warnings (default: false)
-```
-
-### ✅ Validation
-
-Validate a navigation.json file (schema + custom cross-node checks):
+## Quick start
 
 ```bash
-# Validate and print issues (non-zero exit only if --strict)
-vtex-nav validate ./public/navigation.json
+# Generate navigation (writes ./generated-navigation.json)
+vtex-nav gen
 
-# Fail the build if any errors are found
-vtex-nav validate ./public/navigation.json --strict
+# View a navigation file in the terminal
+vtex-nav view --file ./generated-navigation.json
+
+# Validate a navigation file (schema + custom checks)
+vtex-nav validate ./generated-navigation.json --strict
 ```
 
-What’s validated:
-- Structural JSON Schema (Draft-07)
+For the full list of flags, run `vtex-nav gen --help` and `vtex-nav view --help`.
+
+## How it works
+
+Generation pipeline:
+
+1) Scan content repositories (docs/en|es|pt/*)
+2) Build category hierarchy from the natural folder structure
+3) Link cross-language files and normalize localized names/slugs
+4) Transform into the navigation schema
+5) Validate (JSON Schema + custom checks) and write output
+
+### Folder hierarchy and per‑section rules
+
+- All sections respect the natural folder hierarchy. If the repository is nested, navigation is nested; if folders are flat, navigation is flat.
+- Announcements
+  - Directory layout: year/month/articles
+  - Within each year, months are categories; within each month, articles are listed
+  - Month articles are ordered by the YYYY‑MM‑DD prefix in the filename/slug (newest first)
+- Tracks
+  - Track articles are ordered by the `order` field in frontmatter; we also prefix article titles with positional numbers for better UX
+- Tutorials, FAQ, Troubleshooting, Known Issues
+  - Follow folder hierarchy; documents are sorted alphabetically unless an `order` is present (see below)
+
+### Category names, order and metadata.json
+
+- The generator reads `metadata.json` in category folders (for each language) when present
+  - Uses `name` to set localized category titles
+  - Uses `order` to sort categories; this applies to all sections
+  - Falls back to legacy `order.json` if needed
+- When metadata is absent, names are derived from folder names and categories are sorted alphabetically
+
+### Slugs and cross‑language unification
+
+- Categories and documents use LocalizedString slugs (en/es/pt)
+- Categories across languages are merged by their English slug so they are treated as a single localized entity
+- Document slugs are derived from filenames; for Announcements we only read the leading date to sort but do not alter names
+
+### Validation
+
+- JSON Schema (Draft‑07) at `source/schemas/navigation.schema.json`
   - name and slug are LocalizedString objects with en, es, pt keys
-  - Categories: type=category, children min 1
+  - Categories: type=category, children >= 1
   - Documents: type=markdown, children must be empty
-  - Additional properties are rejected for safety
-- Custom rule: sibling categories under the same parent must have unique english slug (slug.en)
+  - Additional properties are disallowed
+- Custom checks
+  - Sibling categories under the same parent must have unique English slug
+  - Current content check also flags duplicate slugs anywhere in a section (not just siblings). This is conservative and may report Announcements months across different years. We plan to scope this to siblings only.
 
-Notes:
-- Empty strings are allowed in LocalizedString fields to indicate a missing translation. This keeps the structure consistent while signalling gaps.
+## Commands
 
-### 🌳 Viewing Navigation
+- gen: generate navigation
+  - Common flags: `--content-dir`, `--output`, `--languages`, `--sections`, `--branch`, `--verbose`, `--show-warnings`
+- view: inspect a navigation file in the terminal
+- validate: validate a navigation file against the schema + custom rules
 
-#### Basic Viewer Usage
+## Configuration (env)
 
-```bash
-# Run the interactive viewer (downloads navigation.json if not present)
-vtex-nav view
-
-# Use a specific navigation file
-vtex-nav view --file ./custom-navigation.json
-
-# Start in a specific language
-vtex-nav view --language es
-```
-
-#### Viewer Options
+You can provide a `.env` with:
 
 ```
-Options:
-  --file, -f     Path to navigation.json file
-  --language, -l Language to use (en, es, pt) [default: en]
-  --help         Show help
-```
-
-### Keyboard Shortcuts
-
-#### Navigation
-- `↑/↓` - Navigate up/down through items
-- `PgUp/PgDn` - Navigate faster (10 items at a time)
-- `Space` or `Enter` - Expand/collapse current item
-- `a` - Toggle all items expanded/collapsed
-
-#### Language
-- `e` - Switch to English
-- `s` - Switch to Spanish  
-- `p` - Switch to Portuguese
-
-#### Other
-- `h` or `?` - Toggle help screen
-- `i` - Toggle statistics view
-- `q` or `Esc` - Quit the application
-
-## Configuration
-
-You can configure the tool using environment variables:
-
-Create a `.env` file in your project root:
-
-```env
-# URL to fetch navigation.json from
 VTEX_NAVIGATION_URL=https://newhelp.vtex.com/navigation.json
-
-# Default output path for downloaded navigation
 DEFAULT_OUTPUT_PATH=./navigation.json
-
-# Auto-format JSON output
 AUTO_FORMAT_JSON=true
-
-# Request timeout in milliseconds
 REQUEST_TIMEOUT=30000
+```
+
+## Schema overview (brief)
+
+Definitions are in `source/schemas/navigation.schema.json`. A minimal shape:
+
+```
+{
+  "navbar": [
+    {
+      "documentation": "announcements|tracks|...",
+      "name": { "en": "...", "es": "...", "pt": "..." },
+      "slugPrefix": "...",
+      "categories": [
+        {
+          "type": "category",
+          "name": { ... },
+          "slug": { ... },
+          "children": [
+            { "type": "markdown", "name": { ... }, "slug": { ... }, "children": [] }
+          ]
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ## Development
 
-### Setup
-
 ```bash
-# Clone the repository
-git clone https://github.com/yourusername/vtexhelp-nav-cli.git
-cd vtexhelp-nav-cli
-
-# Install dependencies
 npm install
-
-# Build the project
 npm run build
-
-# Run in development mode
 npm run dev
 ```
 
-### Temporary caches and external repositories
-
-This project clones content repositories locally for generation. These folders are temporary, ignored by Git, and can be safely deleted at any time:
-
-- .vtexhelp-content — VTEX Help Center content clone
-- .vtexhelp-known-issues — Known issues repository clone used for categorization
-
-If either folder is missing, the generator will fetch it automatically when needed.
-
-### Project Structure
-
-```
-vtexhelp-nav-cli/
-├── source/
-│   ├── app.tsx                        # Main viewer app component
-│   ├── cli.tsx                        # CLI entry point and command routing
-│   ├── NavigationTree.tsx             # Interactive tree component
-│   ├── commands/
-│   │   ├── generate-simple.tsx        # Simple mode generation command
-│   │   ├── generateCommand.ts         # Command definitions and options
-│   │   └── generate/                  # Generation system
-│   │       ├── index.ts               # Main generation orchestrator
-│   │       ├── simple-generator.ts    # Simple mode generator (Ink-free)
-│   │       ├── scanner.ts             # Content repository scanner
-│   │       ├── categorizer.ts         # Category hierarchy builder
-│   │       ├── linker.ts              # Cross-language document linker
-│   │       ├── transformer.ts         # Navigation format transformer
-│   │       ├── external-repositories.ts # Handles cloning/using external content repos
-│   │       ├── validator.ts           # Navigation validation engine
-│   │       ├── types.ts               # Generation-specific types
-│   │       └── ui/                    # Interactive UI components
-│   │           ├── GenerationDashboard.tsx  # Main dashboard
-│   │           ├── ProgressBar.tsx           # Progress visualization
-│   │           ├── StatsPanel.tsx            # Statistics display
-│   │           └── logger.ts                 # Dual-mode logger
-│   ├── types/
-│   │   └── navigation.ts              # Core navigation types
-│   ├── services/
-│   │   └── navigationService.ts       # Navigation data service
-│   ├── config/
-│   │   └── config.ts                  # Configuration management
-│   └── utils/
-│       └── validateSchema.ts          # Schema validation utilities
-├── source/schemas/
-│   └── navigation.schema.json         # JSON schema for validation
-└── dist/                              # Compiled TypeScript output
-```
-
-## Examples
-
-### 🏗️ Generation Workflow
-
-```bash
-# 1. Generate navigation (perfect for CI/CD)
-vtex-nav gen --verbose --report --output production-nav.json
-
-# 2. Generate with custom branch and specific languages
-vtex-nav gen --branch develop --languages en,pt --force
-
-# 3. Validate generated file
-vtex-nav view --file production-nav.json
-```
-
-### 🌳 Viewer Workflow
-
-```bash
-# 1. Quick view with auto-download
-vtex-nav view
-
-# 2. Browse specific navigation file
-vtex-nav view --file ./my-navigation.json --language es
-
-# 3. Compare different navigation structures
-vtex-nav view --file ./old-nav.json
-vtex-nav view --file ./new-nav.json
-```
-
-### 🔄 Full Development Cycle
-
-```bash
-# Generate fresh navigation
-vtex-nav gen --verbose --report --output latest-nav.json
-
-# Inspect and validate the structure
-vtex-nav view --file latest-nav.json
-
-# Generate detailed report for review
-vtex-nav gen --report --log-file generation.log
-```
-
-## Schema overview
-
-LocalizedString
-- Keys: en, es, pt
-- Value: string (can be empty to indicate missing translation)
-
-NavigationNode
-- name: LocalizedString
-- slug: LocalizedString
-- type: "category" | "markdown"
-- children: NavigationNode[]
-- Rules:
-  - category: children.length >= 1
-  - markdown: children.length == 0
-
-Merging and duplicates
-- Categories across languages are merged by their English slug (slug.en), treating categories as localized entities.
-- Within the same parent, sibling category english slugs must be unique; duplicates are flagged by validation.
-
-## Architecture
-
-### 🎯 Generation Mode
-
-- Simple mode (gen): console logging, optimized performance, clean output
-- Designed for CI/CD and automation
-- Use --verbose for detailed logs and --show-warnings for in-depth analysis
-- No interactive generation mode is available at the moment
-
-### 🏗️ Generation Pipeline
-
-1. **Repository Initialization**: Clones VTEX Help Center content
-2. **Content Scanning**: Parses markdown files across all languages
-3. **Category Building**: Constructs hierarchical category structure
-4. **Cross-language Linking**: Links related documents across languages
-5. **Navigation Transformation**: Converts to VTEX navigation format
-6. **Validation**: Ensures schema compliance and content integrity
-7. **Output Generation**: Writes navigation JSON and optional reports
+Temporary caches created by the generator (safe to delete):
+- `.vtexhelp-content`
+- `.vtexhelp-known-issues`
 
 ## Requirements
 
 - Node.js >= 16
-- Terminal with UTF-8 support for proper character display
 - Git (for content repository cloning)
-- ~100MB disk space for content cache
 
 ## License
 


### PR DESCRIPTION
This PR refreshes the project README to follow common structures seen in top-starred JS/TS repositories in 2025 and adds a focused troubleshooting guide.\n\nSummary\n- Rewrite README to a concise, non-marketing structure (Overview, Install, Quick start, How it works, Per-section rules, Validation, Commands, Schema, Development).\n- Clarify schema details and per-section behaviors:\n  - Announcements: year/month/articles; month articles sorted by YYYY-MM-DD filename prefix (newest first).\n  - Tracks: article order by frontmatter `order` with positional numbering.\n  - Tutorials/FAQ/Troubleshooting/Known Issues: folder hierarchy; alphabetical unless order present.\n- Document metadata.json usage for category names and order; legacy order.json fallback.\n- Add docs/troubleshooting.md with quick fixes, common issues, diagnostics, and a bug report checklist.\n- Remove emoji-heavy content and long feature lists in favor of copy-pastable commands and brief explanations.\n\nMotivation\nInspired by practices in repos like react, next.js, node, vscode, angular, typescript, axios, and others: keep README practical and brief, push deeper material to docs/.\n\nNotes\n- Validation still flags duplicate month slugs across years; we intend to scope this check to siblings only in a follow-up.\n- No changes to output schema.\n\nPreview\n- README: readme.md\n- Troubleshooting: docs/troubleshooting.md\n\nPlease review wording/tone and suggest any sections you want deeper or moved to docs/.