### PR TITLE
feat(generate): allow markdown files and subfolders in the same category

### DIFF
--- a/source/commands/generate/categorizer.ts
+++ b/source/commands/generate/categorizer.ts
@@ -521,7 +521,9 @@ export class CategoryBuilder {
         
         currentMap[levelPath] = {
           name: localizedName,
-          children: isLeafLevel ? this.sortTrackArticles(files, section) : {},
+          children: isLeafLevel
+            ? { files: this.sortTrackArticles(files, section), subcategories: {} }
+            : { files: [], subcategories: {} },
           path: levelPath,
           level: i + 1,
           ...(order !== undefined && { order }),
@@ -535,19 +537,25 @@ export class CategoryBuilder {
           fileCount: isLeafLevel ? files.length : 0,
           order
         });
-      } else if (isLeafLevel && Array.isArray(currentMap[levelPath]!.children)) {
-        // If this is a leaf level and we already have files, merge them
-        const existingFiles = currentMap[levelPath]!.children as ContentFile[];
-        const allFiles = [...existingFiles, ...files];
-        currentMap[levelPath]!.children = this.sortTrackArticles(allFiles, section);
+      } else if (isLeafLevel) {
+        // Merge direct .md files at this level (may coexist with subcategories)
+        const entry = currentMap[levelPath]!;
+        const prev = entry.children;
+        const mergedFiles = this.sortTrackArticles([...prev.files, ...files], section);
+        currentMap[levelPath] = {
+          ...entry,
+          children: {
+            files: mergedFiles,
+            subcategories: prev.subcategories,
+          },
+        };
       }
-      
+
       // Move to the next level for non-leaf nodes
       if (!isLeafLevel) {
         currentPath = levelPath;
-        if (typeof currentMap[levelPath]!.children === 'object' && !Array.isArray(currentMap[levelPath]!.children)) {
-          currentMap = currentMap[levelPath]!.children as CategoryMap;
-        }
+        const sub = currentMap[levelPath]!.children.subcategories;
+        currentMap = sub;
       }
     }
   }
@@ -752,8 +760,8 @@ export class CategoryBuilder {
     
     for (const [, category] of Object.entries(categoryMap)) {
       count++;
-      if (category.children && typeof category.children === 'object' && !Array.isArray(category.children)) {
-        count += this.countCategories(category.children as CategoryMap);
+      if (category.children?.subcategories) {
+        count += this.countCategories(category.children.subcategories);
       }
     }
     

--- a/source/commands/generate/transformer.ts
+++ b/source/commands/generate/transformer.ts
@@ -9,6 +9,7 @@ import type {
 type NavigationData = any;
 import type {
   CategoryHierarchy,
+  CategoryMap,
   ContentFile,
   GenerationOptions,
   PhaseSummary
@@ -248,76 +249,52 @@ export class NavigationTransformer {
         }
       }
 
-      const children = categoryInfo.children;
+      const children = categoryInfo.children as { files?: ContentFile[]; subcategories?: CategoryMap };
+      const directFiles: ContentFile[] = Array.isArray(children?.files) ? children.files : [];
+      const subcategories: CategoryMap =
+        children?.subcategories && typeof children.subcategories === 'object' ? children.subcategories : {};
 
       // Generate per-locale category slugs from localized names, avoiding conflicts with child document slugs per locale
-      const slug = this.generateLocalizedCategorySlugs(name, children, categoryInfo.localizedMetadata);
+      const slug = this.generateLocalizedCategorySlugs(name, directFiles, categoryInfo.localizedMetadata);
 
-      if (Array.isArray(children)) {
-        // This is a category with documents
-        const documents = await this.buildDocumentNodes(
-          children,
-          hierarchy,
-          sectionProcessedSlugs,
-          slugToFileMap,
-          duplicateWarnings,
-          sectionName
-        );
+      const documentNodes = await this.buildDocumentNodes(
+        directFiles,
+        hierarchy,
+        sectionProcessedSlugs,
+        slugToFileMap,
+        duplicateWarnings,
+        sectionName
+      );
 
-        // Prune empty categories (no leaf documents)
-        if (!documents || documents.length === 0) {
-          return null;
-        }
+      const subcategoryNodes = await this.buildCategoryNodes(
+        subcategories,
+        hierarchy,
+        sectionProcessedSlugs,
+        slugToFileMap,
+        duplicateWarnings,
+        sectionName
+      );
 
-        const node = {
-          name,
-          // Categories now require localized slugs; all locales filled from localized names with conflict resolution
-          slug: slug,
-          origin: '',
-          type: 'category',
-          children: documents,
-        } as NavigationNode;
+      // Subcategories first, then direct markdown (same ordering as mergeCategoryNodeLists)
+      const combinedChildren = [...subcategoryNodes, ...documentNodes];
 
-        // Add order information if available
-        if (typeof categoryInfo.order === 'number') {
-          node.order = categoryInfo.order;
-        }
-
-        return node;
-      } else if (children && typeof children === 'object') {
-        // This is a category with subcategories
-        const subcategoryNodes = await this.buildCategoryNodes(
-          children,
-          hierarchy,
-          sectionProcessedSlugs,
-          slugToFileMap,
-          duplicateWarnings,
-          sectionName
-        );
-
-        // Prune empty categories (no subcategories/documents)
-        if (!subcategoryNodes || subcategoryNodes.length === 0) {
-          return null;
-        }
-
-        const node = {
-          name,
-          slug: slug,
-          origin: '',
-          type: 'category',
-          children: subcategoryNodes,
-        } as NavigationNode;
-
-        // Add order information if available
-        if (typeof categoryInfo.order === 'number') {
-          node.order = categoryInfo.order;
-        }
-
-        return node;
-      } else {
-        this.logger.warn('Invalid category structure', { categoryInfo });
+      if (combinedChildren.length === 0) {
         return null;
       }
+
+      const node = {
+        name,
+        slug: slug,
+        origin: '',
+        type: 'category',
+        children: combinedChildren,
+      } as NavigationNode;
+
+      if (typeof categoryInfo.order === 'number') {
+        node.order = categoryInfo.order;
+      }
+
+      return node;
 
     } catch (error) {
       this.logger.error('Failed to build navigation node', { error, categoryInfo });
@@ -690,7 +667,11 @@ export class NavigationTransformer {
     return Array.from(bySlug.values());
   }
 
-  private generateLocalizedCategorySlugs(name: LocalizedString, children?: any, localizedMetadata?: { [lang: string]: any }): LocalizedString {
+  private generateLocalizedCategorySlugs(
+    name: LocalizedString,
+    documentChildren: ContentFile[],
+    localizedMetadata?: { [lang: string]: any }
+  ): LocalizedString {
     const locales: Array<keyof LocalizedString> = ['en','es','pt'];
 
     // First, try to use slugs from metadata.json (source of truth)
@@ -717,10 +698,10 @@ export class NavigationTransformer {
       }
     }
 
-    // If this is a leaf category with document children, gather child slugs per locale
-    if (Array.isArray(children)) {
+    // If this category has direct .md files, gather their slugs per locale (avoid slug collisions)
+    if (documentChildren.length > 0) {
       const childSlugsByLocale: Record<string, Set<string>> = { en: new Set(), es: new Set(), pt: new Set() };
-      for (const file of children) {
+      for (const file of documentChildren) {
         try {
           const docSlug = this.getDocumentSlug(file);
           const lang = (file?.language || 'en') as keyof LocalizedString;

--- a/source/commands/generate/types.ts
+++ b/source/commands/generate/types.ts
@@ -35,10 +35,16 @@ export interface ContentFile {
   content: string;
 }
 
+/** Markdown files in this folder and/or nested subfolders as categories */
+export interface CategoryChildren {
+  files: ContentFile[];
+  subcategories: CategoryMap;
+}
+
 export interface CategoryMap {
   [categoryPath: string]: {
     name: LocalizedString;
-    children: CategoryMap | ContentFile[];
+    children: CategoryChildren;
     path: string;
     level: number;
     order?: number; // Order from metadata.json or legacy order.json


### PR DESCRIPTION
Na geração da navigation, cada pasta de categoria era tratada como ou lista de artigos (.md) ou mapa de subcategorias. Pastas com artigos ao mesmo nível que subpastas (cenário comum em tracks) não eram modeladas de forma consistente.