### PR TITLE
fix: eliminate structure-driven category cover auto-flatten

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Generation pipeline:
 
 ### Category cover pages
 
-A folder with subfolders can designate one of its direct markdown files as the category's landing page (cover) by adding `categoryCover: true` to its frontmatter. When a cover is set, the category node gets `type: "markdown"` and its `name`/`slug` are taken from the cover file rather than the folder name. The subcategories remain in `children`.
+A folder can designate one of its direct markdown files as the category's landing page (cover) by adding `categoryCover: true` to its frontmatter. When a cover is set, the category node gets `type: "markdown"` and its `name`/`slug` are taken from the cover file rather than the folder name. The other direct files and subcategories remain in `children`.
 
 If more than one file in the same folder is marked `categoryCover: true`, a warning is logged and the folder falls back to a regular `type: "category"`.
 

--- a/readme.md
+++ b/readme.md
@@ -67,19 +67,11 @@ Generation pipeline:
 
 ### Category cover pages
 
-A folder can designate one of its markdown files as the category's landing page (cover). When a cover is set, the category node gets `type: "markdown"` and its `name`/`slug` are taken from the cover file rather than the folder name. The subcategories remain in `children`.
+A folder with subfolders can designate one of its direct markdown files as the category's landing page (cover) by adding `categoryCover: true` to its frontmatter. When a cover is set, the category node gets `type: "markdown"` and its `name`/`slug` are taken from the cover file rather than the folder name. The subcategories remain in `children`.
 
-The cover is determined by folder structure and, when needed, by a frontmatter field:
+If more than one file in the same folder is marked `categoryCover: true`, a warning is logged and the folder falls back to a regular `type: "category"`.
 
-| Folder contents | `categoryCover` field | Result |
-|---|---|---|
-| Single `.md` + subfolders | any | Cover applied automatically |
-| Single `.md`, no subfolders | any | Flattened to a plain markdown node (no category wrapper) |
-| Multiple `.md` + subfolders | none | Regular `type: "category"` |
-| Multiple `.md` + subfolders | `true` on one file | That file becomes the cover |
-| Multiple `.md` + subfolders | `true` on more than one file | Warning logged, falls back to regular category |
-
-To explicitly mark a file as cover when there are sibling markdown files, add to its frontmatter:
+To mark a file as cover, add to its frontmatter:
 
 ```yaml
 categoryCover: true

--- a/run-cover-tests.mjs
+++ b/run-cover-tests.mjs
@@ -152,6 +152,22 @@ await test('Case 1b — single .md + subfolders + categoryCover: true → explic
   assert(node?.slug?.en === 'overview', `expected slug.en=overview, got ${node?.slug?.en}`);
 });
 
+await test('Case 1c — categoryCover: true on a PT-only doc (no EN translation) → cover still matches via slugEN', async () => {
+  const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
+  const node = await buildNode(
+    transformer,
+    makeCategoryInfo('test-category'),
+    makeHierarchy(),
+    [makeFile('overview', { categoryCover: true, locale: 'pt' })],
+    makeSubcat('test-category'),
+  );
+  // Match must work via slugEN, not slug.en — slug.en is '' here since there's no
+  // EN translation and no crossLanguageMap entry, which used to make the cover silently
+  // fail to apply (the real-world bug: docs without a matched EN slug never matched).
+  assert(node?.type === 'markdown', `expected type markdown, got ${node?.type}`);
+  assert(node?.slug?.pt === 'overview', `expected slug.pt=overview, got ${node?.slug?.pt}`);
+});
+
 await test('Case 2 — single .md, no subfolders → regular category (no structure-driven flatten)', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(

--- a/run-cover-tests.mjs
+++ b/run-cover-tests.mjs
@@ -125,7 +125,7 @@ async function buildNode(transformer, categoryInfo, hierarchy, directFiles, subc
 
 console.log('\nCategory cover scenarios\n');
 
-await test('Case 1 — single .md + subfolders, no categoryCover → regular category (no structure-driven auto cover)', async () => {
+await test('Case 1: single .md + subfolders, no categoryCover, stays a regular category', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -139,7 +139,7 @@ await test('Case 1 — single .md + subfolders, no categoryCover → regular cat
   assert(childSlugs?.includes('overview'), `expected overview kept as a direct child, got ${JSON.stringify(childSlugs)}`);
 });
 
-await test('Case 1b — single .md + subfolders + categoryCover: true → explicit cover still works', async () => {
+await test('Case 1b: single .md + subfolders with categoryCover: true becomes the cover', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -152,7 +152,7 @@ await test('Case 1b — single .md + subfolders + categoryCover: true → explic
   assert(node?.slug?.en === 'overview', `expected slug.en=overview, got ${node?.slug?.en}`);
 });
 
-await test('Case 1c — categoryCover: true on a PT-only doc (no EN translation) → cover still matches via slugEN', async () => {
+await test('Case 1c: categoryCover: true on a PT-only doc with no EN translation still applies', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -161,14 +161,13 @@ await test('Case 1c — categoryCover: true on a PT-only doc (no EN translation)
     [makeFile('overview', { categoryCover: true, locale: 'pt' })],
     makeSubcat('test-category'),
   );
-  // Match must work via slugEN, not slug.en — slug.en is '' here since there's no
-  // EN translation and no crossLanguageMap entry, which used to make the cover silently
-  // fail to apply (the real-world bug: docs without a matched EN slug never matched).
+  // slug.en is '' here since there's no EN translation and no crossLanguageMap
+  // entry, so the match has to go through slugEN instead.
   assert(node?.type === 'markdown', `expected type markdown, got ${node?.type}`);
   assert(node?.slug?.pt === 'overview', `expected slug.pt=overview, got ${node?.slug?.pt}`);
 });
 
-await test('Case 2 — single .md, no subfolders → regular category (no structure-driven flatten)', async () => {
+await test('Case 2: single .md, no subfolders, stays a regular category', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -181,7 +180,7 @@ await test('Case 2 — single .md, no subfolders → regular category (no struct
   assert(node?.children?.length === 1, `expected one child, got ${node?.children?.length}`);
 });
 
-await test('Case 3 — multiple .md + subfolders, no categoryCover → regular category', async () => {
+await test('Case 3: multiple .md + subfolders, no categoryCover, stays a regular category', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -193,7 +192,7 @@ await test('Case 3 — multiple .md + subfolders, no categoryCover → regular c
   assert(node?.type === 'category', `expected type category, got ${node?.type}`);
 });
 
-await test('Case 4 — multiple .md + subfolders, one categoryCover: true → that file becomes cover', async () => {
+await test('Case 4: multiple .md + subfolders, one categoryCover: true, that file becomes the cover', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -208,7 +207,7 @@ await test('Case 4 — multiple .md + subfolders, one categoryCover: true → th
   assert(childSlugs?.some(s => s === 'getting-started'), `expected getting-started in children, got ${JSON.stringify(childSlugs)}`);
 });
 
-await test('Case 5 — multiple categoryCover: true → warning logged, falls back to regular category', async () => {
+await test('Case 5: multiple categoryCover: true, warning logged, falls back to regular category', async () => {
   const warnings = [];
   const transformer = new NavigationTransformer(makeLogger(warnings), defaultOptions);
   const node = await buildNode(
@@ -222,7 +221,7 @@ await test('Case 5 — multiple categoryCover: true → warning logged, falls ba
   assert(warnings.some(w => w.includes('Multiple files with categoryCover: true')), `expected warning, got: ${warnings}`);
 });
 
-await test('Case 6 — EN/PT/ES variants of same slugEN, no categoryCover → regular category (no auto cover)', async () => {
+await test('Case 6: EN/PT/ES variants of same slugEN, no categoryCover, stays a regular category', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -234,7 +233,7 @@ await test('Case 6 — EN/PT/ES variants of same slugEN, no categoryCover → re
   assert(node?.type === 'category', `expected type category, got ${node?.type}`);
 });
 
-await test('Case 6b — EN/PT/ES variants of same slugEN + categoryCover: true on PT → cover fires once (slugEN dedup)', async () => {
+await test('Case 6b: EN/PT/ES variants of same slugEN with categoryCover: true on PT, cover fires once (slugEN dedup)', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -247,7 +246,7 @@ await test('Case 6b — EN/PT/ES variants of same slugEN + categoryCover: true o
   assert(node?.slug?.en === 'overview', `expected slug.en=overview, got ${node?.slug?.en}`);
 });
 
-await test('Case 8 — categoryCover: true on an EN file warns that it should be set on PT', async () => {
+await test('Case 8: categoryCover: true on an EN file warns that it should be set on PT', async () => {
   const warnings = [];
   const transformer = new NavigationTransformer(makeLogger(warnings), defaultOptions);
   const node = await buildNode(
@@ -264,7 +263,7 @@ await test('Case 8 — categoryCover: true on an EN file warns that it should be
   );
 });
 
-await test('Case 9 — categoryCover: true on the PT file does not warn', async () => {
+await test('Case 9: categoryCover: true on the PT file does not warn', async () => {
   const warnings = [];
   const transformer = new NavigationTransformer(makeLogger(warnings), defaultOptions);
   await buildNode(
@@ -280,7 +279,7 @@ await test('Case 9 — categoryCover: true on the PT file does not warn', async 
   );
 });
 
-await test('Case 7 — cover-backed markdown node (via explicit categoryCover) with children is not dropped by pruning', async () => {
+await test('Case 7: cover-backed markdown node with children is not dropped by pruning', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,

--- a/run-cover-tests.mjs
+++ b/run-cover-tests.mjs
@@ -125,7 +125,7 @@ async function buildNode(transformer, categoryInfo, hierarchy, directFiles, subc
 
 console.log('\nCategory cover scenarios\n');
 
-await test('Case 1 — single .md + subfolders → auto cover (type: markdown, slug from cover file)', async () => {
+await test('Case 1 — single .md + subfolders, no categoryCover → regular category (no structure-driven auto cover)', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -134,12 +134,25 @@ await test('Case 1 — single .md + subfolders → auto cover (type: markdown, s
     [makeFile('overview')],
     makeSubcat('test-category'),
   );
-  assert(node?.type === 'markdown', `expected type markdown, got ${node?.type}`);
-  assert(node?.slug?.en === 'overview', `expected slug.en=overview, got ${node?.slug?.en}`);
-  assert(node?.children?.length > 0, 'expected non-empty children');
+  assert(node?.type === 'category', `expected type category, got ${node?.type}`);
+  const childSlugs = node?.children?.map(c => c?.slug?.en ?? c?.slug);
+  assert(childSlugs?.includes('overview'), `expected overview kept as a direct child, got ${JSON.stringify(childSlugs)}`);
 });
 
-await test('Case 2 — single .md, no subfolders → flattened to plain markdown (no category wrapper)', async () => {
+await test('Case 1b — single .md + subfolders + categoryCover: true → explicit cover still works', async () => {
+  const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
+  const node = await buildNode(
+    transformer,
+    makeCategoryInfo('test-category'),
+    makeHierarchy(),
+    [makeFile('overview', { categoryCover: true })],
+    makeSubcat('test-category'),
+  );
+  assert(node?.type === 'markdown', `expected type markdown, got ${node?.type}`);
+  assert(node?.slug?.en === 'overview', `expected slug.en=overview, got ${node?.slug?.en}`);
+});
+
+await test('Case 2 — single .md, no subfolders → regular category (no structure-driven flatten)', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -148,9 +161,8 @@ await test('Case 2 — single .md, no subfolders → flattened to plain markdown
     [makeFile('release-notes-2024')],
     {},
   );
-  assert(node?.type === 'markdown', `expected type markdown, got ${node?.type}`);
-  assert(node?.slug?.en === 'release-notes-2024', `expected slug.en=release-notes-2024, got ${node?.slug?.en}`);
-  assert(!node?.children?.length, 'expected no children on plain markdown node');
+  assert(node?.type === 'category', `expected type category, got ${node?.type}`);
+  assert(node?.children?.length === 1, `expected one child, got ${node?.children?.length}`);
 });
 
 await test('Case 3 — multiple .md + subfolders, no categoryCover → regular category', async () => {
@@ -194,7 +206,7 @@ await test('Case 5 — multiple categoryCover: true → warning logged, falls ba
   assert(warnings.some(w => w.includes('Multiple files with categoryCover: true')), `expected warning, got: ${warnings}`);
 });
 
-await test('Case 6 — EN/PT/ES variants of same slugEN count as one file (auto cover still fires)', async () => {
+await test('Case 6 — EN/PT/ES variants of same slugEN, no categoryCover → regular category (no auto cover)', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
@@ -203,7 +215,20 @@ await test('Case 6 — EN/PT/ES variants of same slugEN count as one file (auto 
     [makeFile('overview', { locale: 'en' }), makeFile('overview', { locale: 'pt' }), makeFile('overview', { locale: 'es' })],
     makeSubcat('test-category'),
   );
-  assert(node?.type === 'markdown', `expected type markdown (auto cover), got ${node?.type}`);
+  assert(node?.type === 'category', `expected type category, got ${node?.type}`);
+});
+
+await test('Case 6b — EN/PT/ES variants of same slugEN + categoryCover: true on PT → cover fires once (slugEN dedup)', async () => {
+  const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
+  const node = await buildNode(
+    transformer,
+    makeCategoryInfo('test-category'),
+    makeHierarchy(),
+    [makeFile('overview', { locale: 'en' }), makeFile('overview', { categoryCover: true, locale: 'pt' }), makeFile('overview', { locale: 'es' })],
+    makeSubcat('test-category'),
+  );
+  assert(node?.type === 'markdown', `expected type markdown (cover), got ${node?.type}`);
+  assert(node?.slug?.en === 'overview', `expected slug.en=overview, got ${node?.slug?.en}`);
 });
 
 await test('Case 8 — categoryCover: true on an EN file warns that it should be set on PT', async () => {
@@ -239,13 +264,13 @@ await test('Case 9 — categoryCover: true on the PT file does not warn', async 
   );
 });
 
-await test('Case 7 — cover-backed markdown node with children is not dropped by pruning', async () => {
+await test('Case 7 — cover-backed markdown node (via explicit categoryCover) with children is not dropped by pruning', async () => {
   const transformer = new NavigationTransformer(makeLogger(), defaultOptions);
   const node = await buildNode(
     transformer,
     makeCategoryInfo('test-category'),
     makeHierarchy(),
-    [makeFile('overview')],
+    [makeFile('overview', { categoryCover: true })],
     makeSubcat('test-category'),
   );
   assert(node != null, 'node should not be null');

--- a/source/commands/generate/simple-generator.ts
+++ b/source/commands/generate/simple-generator.ts
@@ -300,7 +300,12 @@ export class SimpleNavigationGenerator {
         if ('order' in node) {
           delete node.order;
         }
-        
+
+        // Delete internal-only cover-matching marker if present
+        if ('__slugEN' in node) {
+          delete node.__slugEN;
+        }
+
         // Process children recursively
         if (Array.isArray(node.children)) {
           node.children.forEach(removeOrderFromNode);

--- a/source/commands/generate/transformer.ts
+++ b/source/commands/generate/transformer.ts
@@ -279,29 +279,17 @@ export class NavigationTransformer {
         sectionName
       );
 
-      // Use documentNodes.length (deduplicated by slugEN across languages) rather than
-      // directFiles.length, which would count EN + PT + ES versions as separate files.
-      const isSingleFile = documentNodes.length === 1;
       const hasSubcats = subcategoryNodes.length > 0;
 
       let categoryName = name;
       let categorySlug = slug;
       let hasCover = false;
 
-      if (isSingleFile && !hasSubcats) {
-        // Single .md, no subfolders → degenerate, flatten to plain markdown
-        return documentNodes[0] ?? null;
-      } else if (isSingleFile && hasSubcats) {
-        // Single .md + subfolders → auto cover, no frontmatter field needed
-        const coverNode = documentNodes[0];
-        if (coverNode) {
-          categoryName = coverNode.name as LocalizedString;
-          categorySlug = coverNode.slug as LocalizedString;
-          hasCover = true;
-          documentNodes.splice(0, 1);
-        }
-      } else if (hasSubcats) {
-        // Multiple .md files + subfolders → categoryCover: true designates the cover.
+      if (hasSubcats) {
+        // No structure-driven auto cover: a folder with subfolders only becomes a
+        // cover-backed markdown node when a direct .md file explicitly opts in via
+        // categoryCover: true. Otherwise it stays a regular category, regardless of
+        // how many direct .md files it has (including exactly one).
         // Deduplicate by slugEN so EN/PT/ES versions of the same file count as one.
         const coverFiles = directFiles.filter(f => f.metadata.categoryCover === true);
 

--- a/source/commands/generate/transformer.ts
+++ b/source/commands/generate/transformer.ts
@@ -279,15 +279,13 @@ export class NavigationTransformer {
         sectionName
       );
 
-      const hasSubcats = subcategoryNodes.length > 0;
-
       let categoryName = name;
       let categorySlug = slug;
       let hasCover = false;
 
-      if (hasSubcats) {
-        // A folder with subfolders becomes a cover-backed markdown node only when a
-        // direct .md file explicitly opts in via categoryCover: true.
+      if (directFiles.length > 0) {
+        // A category becomes a cover-backed markdown node when a direct .md file
+        // explicitly opts in via categoryCover: true.
         // Deduplicate by slugEN so EN/PT/ES versions of the same file count as one.
         const coverFiles = directFiles.filter(f => f.metadata.categoryCover === true);
 

--- a/source/commands/generate/transformer.ts
+++ b/source/commands/generate/transformer.ts
@@ -311,8 +311,10 @@ export class NavigationTransformer {
           );
         } else if (markedSlugs.size === 1) {
           const coverSlugEN = [...markedSlugs][0];
+          // Match by the __slugEN marker, not slug.en — slug.en is '' for documents
+          // with no EN translation (e.g. PT-only docs), which would otherwise never match.
           const coverNodeIdx = documentNodes.findIndex(
-            n => n.type === 'markdown' && (n.slug as any)?.en === coverSlugEN
+            n => n.type === 'markdown' && (n as any).__slugEN === coverSlugEN
           );
           if (coverNodeIdx !== -1) {
             const coverNode = documentNodes[coverNodeIdx]!;
@@ -439,6 +441,10 @@ export class NavigationTransformer {
         // Build node using the first file (they all have the same slugEN so will get the same cross-language data)
         const node = await this.buildDocumentNode(firstFile, hierarchy);
         if (node) {
+          // Tag with the source slugEN so categoryCover matching doesn't depend on
+          // slug.en being populated (it's '' for documents with no EN translation).
+          // Stripped from the output before writing/validation.
+          (node as any).__slugEN = slugEN;
           nodes.push(node);
         }
       } catch (error) {

--- a/source/commands/generate/transformer.ts
+++ b/source/commands/generate/transformer.ts
@@ -286,10 +286,8 @@ export class NavigationTransformer {
       let hasCover = false;
 
       if (hasSubcats) {
-        // No structure-driven auto cover: a folder with subfolders only becomes a
-        // cover-backed markdown node when a direct .md file explicitly opts in via
-        // categoryCover: true. Otherwise it stays a regular category, regardless of
-        // how many direct .md files it has (including exactly one).
+        // A folder with subfolders becomes a cover-backed markdown node only when a
+        // direct .md file explicitly opts in via categoryCover: true.
         // Deduplicate by slugEN so EN/PT/ES versions of the same file count as one.
         const coverFiles = directFiles.filter(f => f.metadata.categoryCover === true);
 
@@ -311,8 +309,8 @@ export class NavigationTransformer {
           );
         } else if (markedSlugs.size === 1) {
           const coverSlugEN = [...markedSlugs][0];
-          // Match by the __slugEN marker, not slug.en — slug.en is '' for documents
-          // with no EN translation (e.g. PT-only docs), which would otherwise never match.
+          // Match by the __slugEN marker instead of slug.en, since slug.en is empty
+          // for documents with no EN translation.
           const coverNodeIdx = documentNodes.findIndex(
             n => n.type === 'markdown' && (n as any).__slugEN === coverSlugEN
           );


### PR DESCRIPTION
## Summary

Testing the previously merged category-cover feature (#8) against [help-center-content#980](https://github.com/vtexdocs/help-center-content/pull/980) surfaced two problems:

- The structure-driven auto cover (any folder with exactly one direct `.md` file, with or without subfolders, auto-flattened into a `type: "markdown"` node) fired on **every** matching folder across the whole content tree the first time navigation.json was regenerated, not just the intended category. This produced a massive, unintended diff, incorrectly flattening things like Announcements month folders, Storefront Overview, Retail media, etc.
- The one deliberate `categoryCover: true` addition in that PR (on the VTEX CX Platform PT overview doc) silently did **not** apply, because the cover lookup matched the marked file's `slugEN` against the candidate node's `slug.en`, which is `''` whenever the node has no matched EN slug, so the match never happens.

## Changes

- **`refactor: eliminate structure-driven auto cover, categoryCover explicit-only`**: removes the automatic single-file cover/flatten rules. A folder always stays a regular `type: "category"` regardless of how many direct `.md` files it has; `categoryCover: true` on a direct file is now the *only* way to get a cover-backed category.
- **`fix: match categoryCover by slugEN metadata instead of derived slug.en`**: tags each document node with the `slugEN` it was grouped by during construction, and matches `categoryCover` against that instead of `slug.en`. The marker is stripped from the output before validation/write.
- `readme.md` updated to describe the new (explicit-only) cover behavior.
- `run-cover-tests.mjs` updated/extended: rewrote cases that relied on the old auto-cover behavior, added cases covering the slugEN-matching fix (including a PT-only-doc scenario).
- Follow-up cleanup commit: reworded code comments and test descriptions to describe current behavior plainly, without referencing the removed structure-driven auto cover rules.

## Test plan

- [x] `npx tsc` builds clean
- [x] `node run-cover-tests.mjs`, 12/12 passing
- [ ] Regenerate navigation against help-center-content and confirm Announcements/Storefront/etc. are no longer unintentionally flattened, and the VTEX CX Platform PT overview cover now applies